### PR TITLE
[docs] Add LD_LIBRARY_PATH before sc-machine launch quick_start.md

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -26,7 +26,7 @@
 4. Run C++ problem solver:
 
     ```sh
-    ./install/sc-machine/bin/sc-machine -s kb.bin -c ostis-metasystem.ini \
+    LD_LIBRARY_PATH=./install/sc-machine/lib ./install/sc-machine/bin/sc-machine -s kb.bin -c ostis-metasystem.ini \
         -e "install/sc-machine/lib/extensions;install/sc-component-manager/lib/extensions;install/scp-machine/lib/extensions;install/problem-solver/lib/extensions"
     ```
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `quick_start.md` to set `LD_LIBRARY_PATH` before launching `sc-machine`.
> 
>   - **Documentation**:
>     - Update `quick_start.md` to set `LD_LIBRARY_PATH` before launching `sc-machine` to ensure correct library path usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fostis-metasystem&utm_source=github&utm_medium=referral)<sup> for 6fc7d38cac1116edc7fb87f67515944c782e7b5b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->