### PR TITLE
Add examples of reusable components

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Examples of reusable components
+
 ## [0.2.0] - 16.03.2025
 
 ### Added

--- a/sc-models/ostis-metasystem-components-specification.scs
+++ b/sc-models/ostis-metasystem-components-specification.scs
@@ -36,6 +36,210 @@ ostis_metasystem_repository
 			*);;
 		*);;
 	*);;
+*);
+-> part_methods_tools_specification
+(*
+	<- concept_reusable_component_specification;;
+	=> nrel_alternative_addresses:
+	...
+	(*
+		<- sc_node_tuple;;
+		-> rrel_1:
+			...
+			(*
+				-> [https://github.com/MksmOrlov/ostis-kb-lib/tree/main/part_methods_tools]
+					(*
+						<- concept_github_url;;
+					*);;
+			*);;
+	*);;
+*);
+-> part_platform_specification
+(*
+	<- concept_reusable_component_specification;;
+	=> nrel_alternative_addresses:
+	...
+	(*
+		<- sc_node_tuple;;
+		-> rrel_1:
+			...
+			(*
+				-> [https://github.com/MksmOrlov/ostis-kb-lib/tree/main/part_platform/subdir_platform]
+					(*
+						<- concept_github_url;;
+					*);;
+			*);;
+	*);;
+*);
+-> part_ui_specification
+(*
+	<- concept_reusable_component_specification;;
+	=> nrel_alternative_addresses:
+	...
+	(*
+		<- sc_node_tuple;;
+		-> rrel_1:
+			...
+			(*
+				-> [https://github.com/MksmOrlov/ostis-kb-lib/tree/main/part_ui]
+					(*
+						<- concept_github_url;;
+					*);;
+			*);;
+	*);;
+*);
+-> part_menu_of_logical_inference_specification
+(*
+	<- concept_reusable_component_specification;;
+	=> nrel_alternative_addresses:
+	...
+	(*
+		<- sc_node_tuple;;
+		-> rrel_1:
+			...
+			(*
+				-> [https://github.com/MksmOrlov/ostis-kb-lib/tree/main/part_menu/menu_of_logical_inference]
+				(*
+					<- concept_github_url;;
+				*);;
+			*);;
+	*);;
+*);
+-> part_menu_of_agent_of_finding_intersection_of_sets_specification
+(*
+	<- concept_reusable_component_specification;;
+	=> nrel_alternative_addresses:
+	...
+	(*
+		<- sc_node_tuple;;
+		-> rrel_1:
+			...
+			(*
+				-> [https://github.com/MksmOrlov/ostis-kb-lib/tree/main/part_menu/menu_of_agent_of_finding_intersection_of_sets]
+				(*
+					<- concept_github_url;;
+				*);;
+			*);;
+	*);;
+*);
+-> part_agent_of_finding_intersection_of_sets_specification
+(*
+	<- concept_reusable_component_specification;;
+	=> nrel_alternative_addresses:
+	...
+	(*
+		<- sc_node_tuple;;
+		-> rrel_1:
+			...
+			(*
+				-> [https://github.com/MksmOrlov/ostis-kb-lib/tree/main/part_agents/agent_of_finding_intersection_of_sets]
+				(*
+					<- concept_github_url;;
+				*);;
+			*);;
+	*);;
+*);
+-> part_polygons_specification
+(*
+	<- concept_reusable_component_specification;;
+	=> nrel_alternative_addresses:
+	...
+	(*
+		<- sc_node_tuple;;
+		-> rrel_1:
+			...
+			(*
+				-> [https://github.com/MksmOrlov/ostis-kb-lib/tree/main/part_figure/sd_polygons]
+				(*
+					<- concept_github_url;;
+				*);;
+			*);;
+	*);;
+*);
+-> part_triangles_specification
+(*
+	<- concept_reusable_component_specification;;
+	=> nrel_alternative_addresses:
+	...
+	(*
+		<- sc_node_tuple;;
+		-> rrel_1:
+			...
+			(*
+				-> [https://github.com/MksmOrlov/ostis-kb-lib/tree/main/part_figure/sd_triangles]
+				(*
+					<- concept_github_url;;
+				*);;
+			*);;
+	*);;
+*);
+-> lr_about_isosceles_triangle_specification
+(*
+	<- concept_reusable_component_specification;;
+	=> nrel_alternative_addresses:
+	...
+	(*
+		<- sc_node_tuple;;
+		-> rrel_1:
+			...
+			(*
+				-> [https://github.com/MksmOrlov/ostis-kb-lib/tree/main/part_lr/lr_about_isosceles_triangle]
+				(*
+					<- concept_github_url;;
+				*);;
+			*);;
+	*);;
+*);
+-> lr_about_relation_specification
+(*
+	<- concept_reusable_component_specification;;
+	=> nrel_alternative_addresses:
+	...
+	(*
+		<- sc_node_tuple;;
+		-> rrel_1:
+			...
+			(*
+				-> [https://github.com/MksmOrlov/ostis-kb-lib/tree/main/part_lr/lr_about_relation]
+				(*
+					<- concept_github_url;;
+				*);;
+			*);;
+	*);;
+*);
+-> part_figure
+(*
+	<- concept_reusable_component_specification;;
+	=> nrel_alternative_addresses:
+	...
+	(*
+		<- sc_node_tuple;;
+		-> rrel_1:
+			...
+			(*
+				-> [https://github.com/MksmOrlov/ostis-kb-lib/tree/main/part_figure/part_figure]
+				(*
+					<- concept_github_url;;
+				*);;
+			*);;
+	*);;
+*);
+-> part_lr
+(*
+	<- concept_reusable_component_specification;;
+	=> nrel_alternative_addresses:
+	...
+	(*
+		<- sc_node_tuple;;
+		-> rrel_1:
+			...
+			(*
+				-> [https://github.com/MksmOrlov/ostis-kb-lib/tree/main/part_lr/part_lr]
+				(*
+					<- concept_github_url;;
+				*);;
+			*);;
+	*);;
 *);;
 
 concept_need_to_install_components


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add examples of reusable components with specifications and GitHub links to the OSTIS Metasystem.
> 
>   - **Changelog**:
>     - Added entry for examples of reusable components in `changelog.md`.
>   - **Component Specifications**:
>     - Added reusable component specifications in `ostis-metasystem-components-specification.scs` with links to GitHub repositories for `part_methods_tools`, `part_platform`, and `part_ui`.
>     - Added specifications for `part_menu_of_logical_inference`, `part_menu_of_agent_of_finding_intersection_of_sets`, and `part_agent_of_finding_intersection_of_sets`.
>     - Included specifications for `part_polygons`, `part_triangles`, `lr_about_isosceles_triangle`, and `lr_about_relation`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ostis-ai%2Fostis-metasystem&utm_source=github&utm_medium=referral)<sup> for 9a316325ba588a4fdfd1fc09f83a1b951d9fbb50. You can [customize](https://app.ellipsis.dev/ostis-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->